### PR TITLE
fix: remove DeleteUserAsync(int id) from IUserRepository

### DIFF
--- a/Server/JokesOnYou.Web.Api/Repositories/Interfaces/IUserRepository.cs
+++ b/Server/JokesOnYou.Web.Api/Repositories/Interfaces/IUserRepository.cs
@@ -12,6 +12,5 @@ namespace JokesOnYou.Web.Api.Repositories.Interfaces
         Task DeleteUserAsync(User user);
         Task<User> GetUserAsync(string id);
         Task<IEnumerable<User>> GetUsersAsync();
-        Task DeleteUserAsync(int id);
     }
 }


### PR DESCRIPTION
The id is not an int and we already have DeleteUserAsync(User user);