### PR TITLE
Implemented GetJoke feature

### DIFF
--- a/Server/JokesOnYou.Web.Api/Controllers/JokesController.cs
+++ b/Server/JokesOnYou.Web.Api/Controllers/JokesController.cs
@@ -1,11 +1,9 @@
-﻿using JokesOnYou.Web.Api.DTOs;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using JokesOnYou.Web.Api.DTOs;
 using JokesOnYou.Web.Api.Services.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace JokesOnYou.Web.Api.Controllers
 {
@@ -27,6 +25,14 @@ namespace JokesOnYou.Web.Api.Controllers
         {
             var jokeDtos = await _jokesService.GetAllJokeDtosAsync();
             return Ok(jokeDtos);
+        }
+
+        [AllowAnonymous]
+        [HttpGet("{id}")]
+        public async Task<ActionResult<JokeReplyDto>> GetJoke(int id)
+        {
+            var joke = await _jokesService.GetJokeDtoAsync(id);
+            return joke;
         }
 
     }

--- a/Server/JokesOnYou.Web.Api/Repositories/Interfaces/IJokesRepository.cs
+++ b/Server/JokesOnYou.Web.Api/Repositories/Interfaces/IJokesRepository.cs
@@ -11,5 +11,6 @@ namespace JokesOnYou.Web.Api.Repositories.Interfaces
     {
         public Task<IEnumerable<Joke>> GetAllJokesAsync();
         public Task<IEnumerable<JokeReplyDto>> GetAllJokeDtosAsync();
+        public Task<JokeReplyDto> GetJokeDtoAsync(int id);
     }
 }

--- a/Server/JokesOnYou.Web.Api/Repositories/Interfaces/IJokesRepository.cs
+++ b/Server/JokesOnYou.Web.Api/Repositories/Interfaces/IJokesRepository.cs
@@ -1,16 +1,14 @@
-﻿using JokesOnYou.Web.Api.DTOs;
-using JokesOnYou.Web.Api.Models;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using JokesOnYou.Web.Api.DTOs;
+using JokesOnYou.Web.Api.Models;
 
 namespace JokesOnYou.Web.Api.Repositories.Interfaces
 {
     public interface IJokesRepository
     {
-        public Task<IEnumerable<Joke>> GetAllJokesAsync();
-        public Task<IEnumerable<JokeReplyDto>> GetAllJokeDtosAsync();
-        public Task<JokeReplyDto> GetJokeDtoAsync(int id);
+        Task<IEnumerable<Joke>> GetAllJokesAsync();
+        Task<IEnumerable<JokeReplyDto>> GetAllJokeDtosAsync();
+        Task<JokeReplyDto> GetJokeDtoAsync(int id);
     }
 }

--- a/Server/JokesOnYou.Web.Api/Repositories/JokesRepository.cs
+++ b/Server/JokesOnYou.Web.Api/Repositories/JokesRepository.cs
@@ -25,7 +25,7 @@ namespace JokesOnYou.Web.Api.Repositories
 
         public async Task<IEnumerable<Joke>> GetAllJokesAsync()
         {
-            var jokes = await _context.Jokes.Include( joke => joke.Author).ToListAsync();
+            var jokes = await _context.Jokes.Include(joke => joke.Author).ToListAsync();
             return jokes;
         }
 
@@ -34,6 +34,12 @@ namespace JokesOnYou.Web.Api.Repositories
             var jokeDtos = await _context.Jokes.ProjectTo<JokeReplyDto>(_mapper.ConfigurationProvider).ToListAsync();
 
             return jokeDtos;
+        }
+
+        public Task<JokeReplyDto> GetJokeDtoAsync(int id)
+        {
+            return _context.Jokes.ProjectTo<JokeReplyDto>(_mapper.ConfigurationProvider)
+                .FirstOrDefaultAsync(j => j.Id == id);
         }
     }
 }

--- a/Server/JokesOnYou.Web.Api/Services/Interfaces/IJokesService.cs
+++ b/Server/JokesOnYou.Web.Api/Services/Interfaces/IJokesService.cs
@@ -1,13 +1,12 @@
-﻿using JokesOnYou.Web.Api.DTOs;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Threading.Tasks;
+using JokesOnYou.Web.Api.DTOs;
 
 namespace JokesOnYou.Web.Api.Services.Interfaces
 {
     public interface IJokesService
     {
         public Task<IEnumerable<JokeReplyDto>> GetAllJokeDtosAsync();
+        Task<JokeReplyDto> GetJokeDtoAsync(int id);
     }
 }

--- a/Server/JokesOnYou.Web.Api/Services/Interfaces/IJokesService.cs
+++ b/Server/JokesOnYou.Web.Api/Services/Interfaces/IJokesService.cs
@@ -6,7 +6,7 @@ namespace JokesOnYou.Web.Api.Services.Interfaces
 {
     public interface IJokesService
     {
-        public Task<IEnumerable<JokeReplyDto>> GetAllJokeDtosAsync();
+        Task<IEnumerable<JokeReplyDto>> GetAllJokeDtosAsync();
         Task<JokeReplyDto> GetJokeDtoAsync(int id);
     }
 }

--- a/Server/JokesOnYou.Web.Api/Services/JokesService.cs
+++ b/Server/JokesOnYou.Web.Api/Services/JokesService.cs
@@ -1,23 +1,19 @@
-﻿using AutoMapper;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using AutoMapper;
 using JokesOnYou.Web.Api.DTOs;
 using JokesOnYou.Web.Api.Repositories.Interfaces;
 using JokesOnYou.Web.Api.Services.Interfaces;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace JokesOnYou.Web.Api.Services
 {
     public class JokesService : IJokesService
     {
         private readonly IJokesRepository _jokesRepo;
-        private readonly IMapper _mapper;
 
-        public JokesService(IJokesRepository jokesRepo, IMapper mapper)
+        public JokesService(IJokesRepository jokesRepo)
         {
             _jokesRepo = jokesRepo;
-            _mapper = mapper;
         }
 
         public async Task<IEnumerable<JokeReplyDto>> GetAllJokeDtosAsync()
@@ -25,6 +21,11 @@ namespace JokesOnYou.Web.Api.Services
             var jokeDtos = await _jokesRepo.GetAllJokeDtosAsync();
 
             return jokeDtos;
+        }
+
+        public Task<JokeReplyDto> GetJokeDtoAsync(int id)
+        {
+            return _jokesRepo.GetJokeDtoAsync(id);
         }
     }
 }


### PR DESCRIPTION
closes #72 

Theres no need to check if the item is null when just returning a get request to the client. If the response is empty the client recieves a NoContent.

Tested with theese urls: 
- https://localhost:5001/api/Jokes/1 (existing joke) => Ok(JokeDto)
- https://localhost:5001/api/Jokes/55 (doesnt exist) => NoContent()