### PR TITLE
Add: UserJokeTag Feature.

### DIFF
--- a/Server/JokesOnYou.Web.Api/Data/DataContext.cs
+++ b/Server/JokesOnYou.Web.Api/Data/DataContext.cs
@@ -21,5 +21,6 @@ namespace JokesOnYou.Web.Api.Data
         public DbSet<Joke> Jokes { get; set; }
 
         public DbSet<Tag> Tags { get; set; }
+        public DbSet<UserJokeTag> UserJokeTags { get; set; }
     }
 }

--- a/Server/JokesOnYou.Web.Api/Data/Migrations/20211117035806_UserJokeTagModel.Designer.cs
+++ b/Server/JokesOnYou.Web.Api/Data/Migrations/20211117035806_UserJokeTagModel.Designer.cs
@@ -4,14 +4,16 @@ using JokesOnYou.Web.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 namespace JokesOnYou.Web.Api.Data.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20211117035806_UserJokeTagModel")]
+    partial class UserJokeTagModel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Server/JokesOnYou.Web.Api/Data/Migrations/20211117035806_UserJokeTagModel.cs
+++ b/Server/JokesOnYou.Web.Api/Data/Migrations/20211117035806_UserJokeTagModel.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace JokesOnYou.Web.Api.Data.Migrations
+{
+    public partial class UserJokeTagModel : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserJokeTags",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    UserId = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    JokeId = table.Column<int>(type: "int", nullable: false),
+                    TagId = table.Column<int>(type: "int", nullable: false),
+                    TaggedDate = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    Likes = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserJokeTags", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserJokeTags");
+        }
+    }
+}

--- a/Server/JokesOnYou.Web.Api/Extensions/ServiceExtensions.cs
+++ b/Server/JokesOnYou.Web.Api/Extensions/ServiceExtensions.cs
@@ -38,6 +38,7 @@ namespace JokesOnYou.Web.Api.Extensions
             services.AddScoped<IJokesRepository, JokesRepository>();
             services.AddScoped<ITagRepository, TagRepository>();
             services.AddScoped<ISavedJokeRepository, SavedJokeRepository>();
+            services.AddScoped<IUserJokeTagRepository, UserJokeTagRepository>();
             services.AddDbContext<DataContext>(options =>
             {
                 options.UseSqlServer(config.GetConnectionString("SQLserverConnection"));

--- a/Server/JokesOnYou.Web.Api/Models/Request/TagCreateDto.cs
+++ b/Server/JokesOnYou.Web.Api/Models/Request/TagCreateDto.cs
@@ -6,5 +6,6 @@ namespace JokesOnYou.Web.Api.Models.Request
     {
         [Required]
         public string Name { get; set; }
+        public int JokeId { get; set; }
     }
 }

--- a/Server/JokesOnYou.Web.Api/Models/Tag.cs
+++ b/Server/JokesOnYou.Web.Api/Models/Tag.cs
@@ -11,8 +11,6 @@ namespace JokesOnYou.Web.Api.Models
         public int Id { get; set; }
         public string Name { get; set; }
         public DateTime Created { get; set; } = DateTime.UtcNow;
-        [NotMapped]
-        public ICollection<int> Jokes { get; set; } = new List<int>();
         public string OwnerId { get; set; }
         public int Likes { get; set; }
     }

--- a/Server/JokesOnYou.Web.Api/Models/UserJokeTag.cs
+++ b/Server/JokesOnYou.Web.Api/Models/UserJokeTag.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace JokesOnYou.Web.Api.Models
+{
+    public class UserJokeTag
+    {
+        public int Id { get; set; }
+        public string UserId { get; set; }
+        public int JokeId { get; set; }
+        public int TagId { get; set; }
+        public DateTime TaggedDate { get; set; } = DateTime.UtcNow;
+        public int Likes { get; set; }
+    }
+}

--- a/Server/JokesOnYou.Web.Api/Repositories/Interfaces/IUserJokeTagRepository.cs
+++ b/Server/JokesOnYou.Web.Api/Repositories/Interfaces/IUserJokeTagRepository.cs
@@ -1,0 +1,13 @@
+﻿using JokesOnYou.Web.Api.Models;
+using JokesOnYou.Web.Api.Models.Request;
+using System.Threading.Tasks;
+
+namespace JokesOnYou.Web.Api.Repositories.Interfaces
+{
+    public interface IUserJokeTagRepository
+    {
+        Task CreateUserJokeTagAsync(UserJokeTag userJokeTag);
+        Task<UserJokeTag> GetUserJokeTagAsync(UserJokeTag userJokeTag);
+        Task<UserJokeTag> GetUSerJokeTagAsync(int id);
+    }
+}

--- a/Server/JokesOnYou.Web.Api/Repositories/UserJokeTagRepository.cs
+++ b/Server/JokesOnYou.Web.Api/Repositories/UserJokeTagRepository.cs
@@ -1,0 +1,34 @@
+﻿using AutoMapper;
+using JokesOnYou.Web.Api.Data;
+using JokesOnYou.Web.Api.Models;
+using JokesOnYou.Web.Api.Models.Request;
+using JokesOnYou.Web.Api.Repositories.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace JokesOnYou.Web.Api.Repositories
+{
+    public class UserJokeTagRepository : IUserJokeTagRepository
+    {
+        private readonly DataContext _context;
+        private readonly IMapper _mapper;
+
+        public UserJokeTagRepository(DataContext context, IMapper mapper)
+        {
+            _context = context;
+            _mapper = mapper;
+        }
+
+        public async Task CreateUserJokeTagAsync(UserJokeTag userJokeTag) => 
+            await _context.UserJokeTags.AddAsync(userJokeTag);
+
+        public async Task<UserJokeTag> GetUSerJokeTagAsync(int id) => 
+            await _context.UserJokeTags.FirstOrDefaultAsync(x => x.Id == id);
+
+        public async Task<UserJokeTag> GetUserJokeTagAsync(UserJokeTag userJokeTag) => 
+             await _context.UserJokeTags.FirstOrDefaultAsync(x =>
+                                                        x.JokeId == userJokeTag.JokeId && 
+                                                        x.TagId == userJokeTag.TagId);
+    }
+}


### PR DESCRIPTION
So this PR changes the Create Tag method.
UserStory:
1. User on the website is on a joke and would like to add a Tag to it.
2. User fills in a Name ( Dad) and presses enter.
3. Website: calls the Create Tag method api/Tag POST with the name of the tag and the Joke Id.
4. Server: will check if the Tag exists and create it if not.
5. Server: Check if the Connection exists And create it if not.
6. Server: if it does Exist it will add a like to the Connection through LikeForTag.
7. server: will send back the Created or Liked Tag.
8. Website: Will show the Liked/Created Tag with the Joke.

Added:
- UserJokeTag Model with Database.
- Changed Create Tag to Create Tag and create a UserJokeTag
- if UserJokeTag Exists it Should redirect to LikeForTag. (does not do so yet will be added in update)

This needs a few tweaks to make it work good.

Comment: The UserJokeTag should be deleted as soon as likes reaches 0;

closes #89 
